### PR TITLE
Fix PEP 668 externally-managed-environment error

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -142,7 +142,8 @@ check_and_install_python() {
             dnf install -y python3-pip
         else
             # Устанавливаем pip через get-pip.py
-            curl -sSL https://bootstrap.pypa.io/get-pip.py | python3
+            curl -sSL https://bootstrap.pypa.io/get-pip.py | python3 - --break-system-packages 2>/dev/null || \
+            curl -sSL https://bootstrap.pypa.io/get-pip.py | python3 - --user
         fi
         
         print_success "pip3 установлен"
@@ -150,7 +151,10 @@ check_and_install_python() {
     
     # Обновляем pip до последней версии
     print_step "Обновление pip..."
-    python3 -m pip install --upgrade pip
+    # Используем --break-system-packages для обхода PEP 668 ограничений
+    python3 -m pip install --upgrade pip --break-system-packages 2>/dev/null || \
+    python3 -m pip install --upgrade pip --user 2>/dev/null || \
+    print_warning "Не удалось обновить pip, но это не критично"
     
     print_success "Python $PYTHON_VERSION готов к использованию"
 }
@@ -333,7 +337,10 @@ install_python_deps() {
         else
             pip install pytoyoda
         fi
-    "
+    " || {
+        print_error "Ошибка установки Python зависимостей"
+        exit 1
+    }
     
     print_success "Python зависимости установлены"
 }


### PR DESCRIPTION
- Added --break-system-packages flag to pip upgrade commands
- Added fallback to --user installation if system packages fail
- Added error handling for Python dependencies installation
- Fixed get-pip.py installation to handle PEP 668 restrictions
- Added graceful fallback with warning if pip upgrade fails

This resolves the 'externally-managed-environment' error on modern Python installations like Raspberry Pi OS with Python 3.11.