### PR TITLE
Add missing importlib-metadata dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -44,6 +44,7 @@ pytz==2023.3
 # Валидация и утилиты
 validators==0.22.0
 python-multipart==0.0.6
+importlib-metadata>=4.0.0
 
 # Интеграции
 paho-mqtt==1.6.1


### PR DESCRIPTION
- Added importlib-metadata>=4.0.0 to requirements.txt
- Fixes ModuleNotFoundError: No module named 'importlib_metadata'
- Required by pytoyoda/__init__.py for version metadata handling
- Resolves service startup failure after installation

This completes the dependency fixes for successful Toyota Dashboard deployment.