### PR TITLE
Fix uninstall script interactive input issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,8 +233,11 @@ sudo systemctl start toyota-dashboard
 
 ### Полное удаление
 ```bash
-# Одна команда для полного удаления
+# Интерактивное удаление (с подтверждением)
 curl -sSL https://raw.githubusercontent.com/sanfisko/toyota-dashboard/main/uninstall.sh | sudo bash
+
+# Автоматическое удаление (без подтверждения)
+curl -sSL https://raw.githubusercontent.com/sanfisko/toyota-dashboard/main/uninstall.sh | sudo bash -s -- -y
 ```
 
 ### Что удаляется

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -5,6 +5,31 @@
 
 set -e
 
+# Параметры
+AUTO_CONFIRM=false
+
+# Обработка аргументов
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -y|--yes)
+            AUTO_CONFIRM=true
+            shift
+            ;;
+        -h|--help)
+            echo "Использование: $0 [опции]"
+            echo "Опции:"
+            echo "  -y, --yes    Автоматическое подтверждение удаления"
+            echo "  -h, --help   Показать эту справку"
+            exit 0
+            ;;
+        *)
+            echo "Неизвестная опция: $1"
+            echo "Используйте -h для справки"
+            exit 1
+            ;;
+    esac
+done
+
 # Цвета для вывода
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -58,6 +83,12 @@ confirm_uninstall() {
     echo
     print_warning "Данные Toyota credentials и история поездок будут потеряны!"
     echo
+    
+    if [[ "$AUTO_CONFIRM" == "true" ]]; then
+        print_info "Автоматическое подтверждение включено (-y флаг)"
+        print_info "Начинаем удаление..."
+        return 0
+    fi
     
     read -p "Вы уверены, что хотите удалить Toyota Dashboard? (yes/no): " -r
     if [[ ! $REPLY =~ ^[Yy][Ee][Ss]$ ]]; then


### PR DESCRIPTION
- Added -y/--yes flag for automatic confirmation in uninstall script
- Fixed script hanging when used with curl | bash due to stdin issues
- Updated README with both interactive and automatic uninstall commands
- Added help option (-h/--help) to uninstall script
- Improved user experience for remote script execution

Now users can use:
- Interactive: curl ... | sudo bash
- Automatic: curl ... | sudo bash -s -- -y