### PR TITLE
Fix uninstall script terminal detection like install.sh

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -84,23 +84,32 @@ confirm_uninstall() {
     print_warning "Данные Toyota credentials и история поездок будут потеряны!"
     echo
     
+    # Если указан флаг -y, пропускаем подтверждение
     if [[ "$AUTO_CONFIRM" == "true" ]]; then
         print_info "Автоматическое подтверждение включено (-y флаг)"
         print_info "Начинаем удаление..."
         return 0
     fi
     
-    read -p "Вы уверены, что хотите удалить Toyota Dashboard? (yes/no): " -r
-    if [[ ! $REPLY =~ ^[Yy][Ee][Ss]$ ]]; then
-        print_info "Удаление отменено"
-        exit 0
-    fi
-    
-    echo
-    read -p "Введите 'DELETE' для подтверждения: " -r
-    if [[ $REPLY != "DELETE" ]]; then
-        print_info "Удаление отменено"
-        exit 0
+    # Проверяем доступность терминала
+    if [[ -t 0 ]] || [[ -c /dev/tty ]]; then
+        # Терминал доступен - запрашиваем подтверждение
+        read -p "Вы уверены, что хотите удалить Toyota Dashboard? (yes/no): " -r
+        if [[ ! $REPLY =~ ^[Yy][Ee][Ss]$ ]]; then
+            print_info "Удаление отменено"
+            exit 0
+        fi
+        
+        echo
+        read -p "Введите 'DELETE' для подтверждения: " -r
+        if [[ $REPLY != "DELETE" ]]; then
+            print_info "Удаление отменено"
+            exit 0
+        fi
+    else
+        # Терминал недоступен (curl | bash) - автоматическое подтверждение
+        print_info "Терминал недоступен для интерактивного ввода."
+        print_info "Автоматическое удаление Toyota Dashboard..."
     fi
 }
 


### PR DESCRIPTION
- Added terminal availability check ([[ -t 0 ]] || [[ -c /dev/tty ]])
- Auto-proceed when terminal unavailable (curl | bash scenario)
- Matches install.sh behavior for consistent user experience
- No more hanging when used with curl | bash
- Interactive confirmation only when terminal is available

Now works seamlessly with: curl -sSL "...uninstall.sh" | sudo bash