### PR TITLE
Add missing hishel dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ sqlalchemy==2.0.23
 # HTTP клиент и Toyota API
 httpx==0.25.2
 aiohttp>=3.9.0
+hishel>=0.0.24
 
 # Конфигурация
 pyyaml==6.0.1


### PR DESCRIPTION
- Added hishel>=0.0.24 to requirements.txt
- Fixes ModuleNotFoundError: No module named 'hishel'
- Required by pytoyoda/controller.py for HTTP caching
- Resolves final service startup failure

✅ FINAL: All dependencies now complete for successful deployment!