### PR TITLE
Упрощение systemd service и улучшение диагностики

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -423,6 +423,18 @@ diagnose_permissions() {
         print_error "Создание директорий в .config НЕ работает"
     fi
     
+    print_info "6. Проверка переменных окружения процесса:"
+    if pgrep -f "toyota-dashboard" >/dev/null; then
+        PID=$(pgrep -f "toyota-dashboard" | head -1)
+        print_info "PID процесса: $PID"
+        print_info "Переменные окружения процесса:"
+        sudo cat /proc/$PID/environ | tr '\0' '\n' | grep -E "(HOME|XDG|PYTHONPATH)" || print_warning "Переменные не найдены"
+        print_info "Рабочая директория процесса:"
+        sudo readlink /proc/$PID/cwd || print_warning "Не удалось определить рабочую директорию"
+    else
+        print_warning "Процесс toyota-dashboard не найден"
+    fi
+    
     echo
     print_success "Диагностика завершена"
 }

--- a/toyota-dashboard.service
+++ b/toyota-dashboard.service
@@ -7,30 +7,17 @@ Wants=network.target
 Type=simple
 User=toyota
 Group=toyota
-WorkingDirectory=/home/toyota
+WorkingDirectory=/opt/toyota-dashboard
 Environment=HOME=/home/toyota
 Environment=XDG_CACHE_HOME=/home/toyota/.cache
 Environment=HTTPX_CACHE_DIR=/home/toyota/.cache/toyota-dashboard
 Environment=PYTHONPATH=/opt/toyota-dashboard
-# Директории должны быть созданы при установке
 ExecStart=/opt/toyota-dashboard/venv/bin/python /opt/toyota-dashboard/app.py
 Restart=always
 RestartSec=10
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=toyota-dashboard
-
-# Безопасность
-NoNewPrivileges=true
-PrivateTmp=true
-ProtectSystem=strict
-ProtectHome=false
-ReadWritePaths=/home/toyota/.cache
-ReadWritePaths=/home/toyota/.config
-ReadWritePaths=/home/toyota/.local
-ReadWritePaths=/var/log/toyota-dashboard
-ReadWritePaths=/var/lib/toyota-dashboard
-ReadWritePaths=/tmp/toyota-dashboard
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
- Удалены все security restrictions из toyota-dashboard.service
- Убраны ProtectSystem, ProtectHome, NoNewPrivileges, PrivateTmp
- Убраны ReadWritePaths ограничения
- Изменена WorkingDirectory на /opt/toyota-dashboard
- Добавлена диагностика переменных окружения процесса
- Добавлена проверка рабочей директории процесса

Это должно решить проблему Permission denied при доступе к /home/toyota