### PR TITLE
Исправление WorkingDirectory в systemd unit файле

### DIFF
--- a/toyota-dashboard.service
+++ b/toyota-dashboard.service
@@ -7,7 +7,7 @@ Wants=network.target
 Type=simple
 User=toyota
 Group=toyota
-WorkingDirectory=/opt/toyota-dashboard
+WorkingDirectory=/home/toyota
 Environment=HOME=/home/toyota
 Environment=XDG_CACHE_HOME=/home/toyota/.cache
 Environment=HTTPX_CACHE_DIR=/home/toyota/.cache/toyota-dashboard


### PR DESCRIPTION
- Изменен WorkingDirectory с /opt/toyota-dashboard на /home/toyota
- Это должно решить проблему с Permission denied для /home/toyota
- Сервис теперь будет запускаться из домашней директории пользователя toyota

Проблема была в том, что systemd запускал процесс из /opt/toyota-dashboard, но процесс пытался создать директории в /home/toyota, что вызывало конфликт прав доступа.